### PR TITLE
fix: typo in bash script code block

### DIFF
--- a/content/en/docs/how-to/install/index.md
+++ b/content/en/docs/how-to/install/index.md
@@ -58,7 +58,6 @@ docker logout
 
 If you're using the **ARM** processor (like Apple Silicon, Apple M1, etc.) - add `:arm` tag at the end of the image name in the above commands.
 ```bash
-```bash
 docker login -u devlikeapro -p {KEY}
 docker pull devlikeapro/waha-plus:arm
 docker logout


### PR DESCRIPTION
The documentation about the Production Ready installation had a small typo: ` ```bash ` was shown inside the code block (it was written twice in the Markdown code).