### PR TITLE
Fix formatting in X-Api-Key HTTP header code example

### DIFF
--- a/content/docs/how-to/security/set-x-api-key-http-header-code.md
+++ b/content/docs/how-to/security/set-x-api-key-http-header-code.md
@@ -6,8 +6,8 @@
 ```bash { title="Set X Api Key Http Header" }
 curl -X 'GET' \
   'http://localhost:3000/api/sessions' \
-  -H 'X-Api-Key: yoursecretkey'
-  -H 'Accept: application/json' \
+  -H 'X-Api-Key: yoursecretkey' \
+  -H 'Accept: application/json'
 ```
 {{< /tab >}}
 


### PR DESCRIPTION
The trailing \ is on the wrong line, making pasting this example generate an error.