### PR TITLE
Document POST /api/sendSticker (GOWS)

### DIFF
--- a/content/docs/how-to/send-messages/api-sendSticker-code.md
+++ b/content/docs/how-to/send-messages/api-sendSticker-code.md
@@ -1,0 +1,94 @@
+<div></div>
+
+{{< tabs "send-sticker-api" "language" >}}
+
+{{< tab "cURL" >}}
+```bash { title="Send Sticker" }
+curl -X 'POST' \
+  'http://localhost:3000/api/sendSticker' \
+  -H 'X-Api-Key: yoursecretkey' \
+  -H 'Accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "session": "default",
+  "chatId": "12132132130@c.us",
+  "file": {
+    "mimetype": "image/webp",
+    "url": "https://example.com/sticker.webp"
+  }
+}'
+```
+{{< /tab >}}
+
+{{< tab "Python" >}}
+```python { title="send-sticker.py" }
+import requests
+
+url = "http://localhost:3000/api/sendSticker"
+headers = {
+    "X-Api-Key": "yoursecretkey",
+    "Content-Type": "application/json",
+}
+data = {
+    "session": "default",
+    "chatId": "12132132130@c.us",
+    "file": {
+        "mimetype": "image/webp",
+        "url": "https://example.com/sticker.webp",
+    },
+}
+response = requests.post(url, json=data, headers=headers)
+print(response.json())
+```
+{{< /tab >}}
+
+{{< tab "JavaScript" >}}
+```javascript { title="send-sticker.js" }
+const url = "http://localhost:3000/api/sendSticker";
+const options = {
+  method: "POST",
+  headers: {
+    "X-Api-Key": "yoursecretkey",
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    session: "default",
+    chatId: "12132132130@c.us",
+    file: {
+      mimetype: "image/webp",
+      url: "https://example.com/sticker.webp",
+    },
+  }),
+};
+const response = await fetch(url, options);
+const data = await response.json();
+console.log(data);
+```
+{{< /tab >}}
+
+{{< tab "PHP" >}}
+```php { title="send-sticker.php" }
+<?php
+$url = "http://localhost:3000/api/sendSticker";
+$data = [
+  "session" => "default",
+  "chatId" => "12132132130@c.us",
+  "file" => [
+    "mimetype" => "image/webp",
+    "url" => "https://example.com/sticker.webp",
+  ],
+];
+$options = [
+  "http" => [
+    "header" => "Content-Type: application/json\r\nX-Api-Key: yoursecretkey\r\n",
+    "method" => "POST",
+    "content" => json_encode($data),
+  ],
+];
+$result = file_get_contents($url, false, stream_context_create($options));
+echo $result;
+```
+{{< /tab >}}
+
+{{< /tabs >}}

--- a/content/docs/how-to/send-messages/features.md
+++ b/content/docs/how-to/send-messages/features.md
@@ -10,6 +10,7 @@
 | `POST /api/sendImage`                                       |                              ✔️                               |  ✔️   | ✔️ ️  |   ✔️   |
 | `POST /api/sendFile`                                        |                              ✔️                               |  ✔️   | ✔️ ️  |   ✔️   |
 | `POST /api/sendVoice`                                       |                              ✔️                               |  ✔️   | ✔️ ️  |   ✔️   |
+| `POST /api/sendSticker`                                     |                                                              |       |  ✔️   |        |
 | `POST /api/sendVideo`                                       |                              ✔️                               |  ✔️   | ✔️ ️  |   ✔️   |
 | `POST /api/sendList`                                        |                                                              |       |  ✔️   |   ✔️   |
 | `POST /api/send/link-custom-preview`                        |                                                              |       | ✔️ ️  |   ✔️   |

--- a/content/docs/how-to/send-messages/index.md
+++ b/content/docs/how-to/send-messages/index.md
@@ -342,6 +342,64 @@ Here's how you can call it from various languages:
 {{< include file="content/docs/how-to/send-messages/media-voice-convert.md" >}}
 
 
+## Send Sticker
+Use API to send a WhatsApp sticker (WebP) to the chat.
+
+```http request
+POST /api/sendSticker
+```
+
+**Engine support:** **GOWS** only for now. Other engines return the standard
+"not implemented by this engine" error.
+
+You can send stickers in two ways:
+
+1. Provide a **URL** for the WebP.
+2. Encode the WebP into **BASE64** and send it in the request body.
+
+{{< tabs "send-sticker-body" >}}
+{{< tab "URL" >}}
+```jsonc { title="Body" }
+{
+  "session": "default",
+  "chatId": "11111111111@c.us",
+  "file": {
+    "mimetype": "image/webp",
+    "url": "https://example.com/sticker.webp"
+  },
+  "reply_to": null
+}
+```
+{{< /tab >}}
+
+{{< tab "BASE64" >}}
+```jsonc { title="Body" }
+{
+  "session": "default",
+  "chatId": "11111111111@c.us",
+  "file": {
+    "mimetype": "image/webp",
+    "filename": "sticker.webp",
+    "data": "<base64-webp>"
+  },
+  "reply_to": null
+}
+```
+{{< /tab >}}
+{{< /tabs >}}
+
+**Fields**:
+- `file` - provide **one of** the fields:
+  - `url` - URL to the WebP
+  - `data` - Base 64 encoded WebP content
+- `reply_to` - optional message id to reply to
+
+{{< include file="content/docs/how-to/send-messages/media-sticker-format.md" >}}
+
+Here's how you can call it from various languages:
+{{< include file="content/docs/how-to/send-messages/api-sendSticker-code.md" >}}
+
+
 ## Send Video
 ```http request
 POST /api/sendVideo

--- a/content/docs/how-to/send-messages/media-sticker-format.md
+++ b/content/docs/how-to/send-messages/media-sticker-format.md
@@ -1,0 +1,24 @@
+<div></div>
+{{< callout context="note" title="Sticker File Format" icon="outline/file" >}}
+`POST /api/sendSticker` is a **dumb** endpoint: it accepts an **already-prepared WebP** and sends it as a sticker.
+There is **no server-side conversion** (jpg/png/gif/mp4 → WebP) and **no EXIF pack/author injection**.
+
+WhatsApp sticker rules (chat stickers):
+
+| Rule | Static | Animated |
+| --- | --- | --- |
+| Format | WebP (`image/webp`) | Animated WebP (`ANMF` / `ANIM`) |
+| Dimensions | Exactly **512 × 512** px | Same |
+| Max size | **≤ 100 KB** | **≤ 500 KB** |
+| Duration | — | **≤ 10 s**, frame duration **≥ 8 ms**, no audio |
+
+Convert on the client (e.g. sharp / FFmpeg) before calling the API:
+
+```bash
+# Static image → WebP 512x512
+ffmpeg -i input.png \
+  -vf "scale=512:512:force_original_aspect_ratio=decrease,format=yuva420p,pad=512:512:(ow-iw)/2:(oh-ih)/2:black@0" \
+  -c:v libwebp -q:v 80 \
+  out.webp
+```
+{{< /callout >}}

--- a/content/docs/overview/changelog/index.md
+++ b/content/docs/overview/changelog/index.md
@@ -62,6 +62,7 @@ Latest Version:
 {{< autolink-prs repo=devlikeapro/waha >}}
 
 🆕 **New**
+- `2026.7.2` - **API / GOWS** - `POST /api/sendSticker` — send a pre-made WebP sticker (static or animated); no server-side conversion - #1287
 - `2026.7.1` - **API** - scoped session keys — narrow media / control keys so you never share the real API key - [**🔒 Keys API**]({{< relref "/docs/how-to/security#scoped-session-keys-media--control" >}}) - fix #2146
 - `2026.7.1` - **GOWS** - Passkey (WebAuthn) session pairing — pair sessions from your own UI - [**How to Handle Passkey**]({{< relref "/blog/waha-passkey" >}})
 - `2026.7.1` - **WEBJS** - expose the current account LID in session "me" info (`me.lid`)


### PR DESCRIPTION
## Summary
- Feature matrix: `POST /api/sendSticker` marked for GOWS.
- Send-messages page: endpoint docs + client WebP requirements (512x512, size limits).
- Changelog entry under 2026.7.

Related: https://github.com/devlikeapro/waha/issues/1287